### PR TITLE
Removing sshpass and adding quotes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "com.github.actions.icon"="upload-cloud"
 LABEL "com.github.actions.color"="orange"
 
 RUN apk update
-RUN apk add openssh sshpass lftp
+RUN apk add lftp
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 777 entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ fi;
 echo "Using $WDEFAULT_METHOD to connect to port $WDEFAULT_PORT"
 
 echo "Uploading files..."
-lftp $WDEFAULT_METHOD://$FTP_SERVER:$WDEFAULT_PORT -u $FTP_USERNAME,$FTP_PASSWORD -e "set ftp:ssl-allow no; mirror $WDEFAULT_ARGS -R $WDEFAULT_LOCAL_DIR $WDEFAULT_REMOTE_DIR; quit"
+lftp $WDEFAULT_METHOD://$FTP_SERVER:$WDEFAULT_PORT -u "$FTP_USERNAME","$FTP_PASSWORD" -e "set ftp:ssl-allow no; mirror $WDEFAULT_ARGS -R $WDEFAULT_LOCAL_DIR $WDEFAULT_REMOTE_DIR; quit"
 
 echo "FTP Deploy Complete"
 exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,6 @@ WDEFAULT_METHOD=${METHOD:-"ftp"}
 
 if [ $WDEFAULT_METHOD = "sftp" ]; then
   WDEFAULT_PORT=${PORT:-"22"}
-  echo "Establishing SFTP connection..."
-  sshpass -p $FTP_PASSWORD sftp -o StrictHostKeyChecking=no -P $WDEFAULT_PORT $FTP_USERNAME@$FTP_SERVER
-  echo "Connection established"
 else
   WDEFAULT_PORT=${PORT:-"21"}
 fi;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ fi;
 echo "Using $WDEFAULT_METHOD to connect to port $WDEFAULT_PORT"
 
 echo "Uploading files..."
-lftp $WDEFAULT_METHOD://$FTP_SERVER:$WDEFAULT_PORT -u "$FTP_USERNAME","$FTP_PASSWORD" -e "set ftp:ssl-allow no; mirror $WDEFAULT_ARGS -R $WDEFAULT_LOCAL_DIR $WDEFAULT_REMOTE_DIR; quit"
+lftp $WDEFAULT_METHOD://$FTP_SERVER:$WDEFAULT_PORT -u "$FTP_USERNAME","$FTP_PASSWORD" -e "set ftp:ssl-allow no; mirror $WDEFAULT_ARGS --reverse $WDEFAULT_LOCAL_DIR $WDEFAULT_REMOTE_DIR; quit"
 
 echo "FTP Deploy Complete"
 exit 0


### PR DESCRIPTION
My hosting provider requires SFTP, but blocks SSH access and that seems to prevent me from using this action as it relies on `sshpass`. It’s unclear to me what the added value of of `sshpass` is, as `lftp` should be capable of handling SFTP connections itself. This pull request assumes `sshpass` isn't required and removes it. Feel free to reject it if I'm overlooking the purpose of having this code in there.

The request also adds quotes around the username and password, as recommended by the `lftp` [instructions](https://lftp.yar.ru/lftp-man.html): “Remember to quote the password properly in the shell.” (Yeah, my SFTP password needed to be escaped otherwise) 

And it uses the verbose `--reverse` argument for readability.