### PR TITLE
adding option to specify command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ I recommend you store your `ftp-password` as a secret.
 | `ftp-username` | Yes       | username@samkirkland.com                      |         | FTP account username                                     |
 | `ftp-password` | Yes       | CrazyUniquePassword&%123                      |         | FTP account password                                     |
 | `local-dir`    | No        | deploy/                                       | ./      | Which local folder to deploy, path should be relative to the root and should include trailing slash. `./` is the root of the project  |
+| `git-ftp-command` | No        | See `git-ftp-command`  below              |         | defaults to push but use any other init, catchup etc. Use catchup to save action minutes first time |
 | `git-ftp-args` | No        | See `git-ftp-args` section below              |         | Custom git-ftp arguments, this field is passed through directly into the git-ftp script |
 | `known-hosts`  | No        | hostname ssh-rsa AAAAB3NzaC1y ...             |         | The desired contents of your .ssh/known_hosts file. See [known hosts setup](#known-hosts-setup) |
 
-#### Advanced options using `git-ftp-args`
+#### Advanced options using `git-ftp-command` and `git-ftp-args`
 Custom arguments, this field is passed through directly into the git-ftp script. See [git-ftp's manual](https://github.com/git-ftp/git-ftp/blob/master/man/git-ftp.1.md) for all options.
 You can use as many arguments as you want, seperate them with a space
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'The local folder to copy, defaults to root project folder'
     defaults: ./
     required: false
+  git-ftp-command:
+    description: 'if you need to do anything else than push. ie catchup '
+    defaults: push
+    required: false    
   git-ftp-args:
     description: 'Passes through options into git-ftp'
     defaults: 

--- a/dist/index.js
+++ b/dist/index.js
@@ -708,6 +708,7 @@ function getUserArguments() {
         ftp_username: core.getInput("ftp-username", { required: true }),
         ftp_password: core.getInput("ftp-password", { required: true }),
         local_dir: withDefault(core.getInput("local-dir"), "./"),
+        gitFtpCommand: withDefault(core.getInput("git-ftp-command"), "push"),
         gitFtpArgs: withDefault(core.getInput("git-ftp-args"), ""),
         knownHosts: withDefault(core.getInput("known-hosts"), "")
     };
@@ -725,7 +726,7 @@ function syncFiles(args) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield core.group("Uploading files", () => __awaiter(this, void 0, void 0, function* () {
-                return yield exec.exec(`git ftp push --force --auto-init --verbose --syncroot ${args.local_dir} --user ${args.ftp_username} --passwd ${args.ftp_password} ${args.gitFtpArgs} ${args.ftp_server}`);
+                return yield exec.exec(`git ftp ${args.gitFtpCommand} --force --auto-init --verbose --syncroot ${args.local_dir} --user ${args.ftp_username} --passwd ${args.ftp_password} ${args.gitFtpArgs} ${args.ftp_server}`);
             }));
         }
         catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ function getUserArguments(): IActionArguments {
     ftp_username: core.getInput("ftp-username", { required: true }),
     ftp_password: core.getInput("ftp-password", { required: true }),
     local_dir: withDefault(core.getInput("local-dir"), "./"),
+    gitFtpCommand: withDefault(core.getInput("git-ftp-command"), "push"),
     gitFtpArgs: withDefault(core.getInput("git-ftp-args"), ""),
     knownHosts: withDefault(core.getInput("known-hosts"), "")
   };
@@ -69,7 +70,7 @@ function withDefault(value: string, defaultValue: string) {
 async function syncFiles(args: IActionArguments) {
   try {
     await core.group("Uploading files", async () => {
-      return await exec.exec(`git ftp push --force --auto-init --verbose --syncroot ${args.local_dir} --user ${args.ftp_username} --passwd ${args.ftp_password} ${args.gitFtpArgs} ${args.ftp_server}`);
+      return await exec.exec(`git ftp ${args.gitFtpCommand} --force --auto-init --verbose --syncroot ${args.local_dir} --user ${args.ftp_username} --passwd ${args.ftp_password} ${args.gitFtpArgs} ${args.ftp_server}`);
     });
   }
   catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ export interface IActionArguments {
 
     /** @default "" */
     gitFtpArgs: string | undefined;
-
+    gitFtpCommand: string | undefined;
+    
     /** @default "" */
     knownHosts: string | undefined;
 }


### PR DESCRIPTION
## Motivation 

First deploy to ftp typically is rather large and costly (action minutes). Therefore we deploy manually first time using any regular ftp client and then run FTP-Deploy-Action with the catchup command.

The catchup command just uploads .git-ftp.log that signals "everything up here" is up to date but does not upload anything. **Huge win**.

## How to use

* Upload files via ftp (first time)
* Make an action workflow that uses FTP-Deploy-Action configured with catchup. Only use this first time or any time you want to signal that all is uploaded.
* Make an action workflow that uses FTP-Deploy-Action configured with push (default) and continue using that for the rest of your life.



