### PR TITLE
Fix problem setting up known-hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,9 @@ jobs:
         ftp-server: sftp://ftp.samkirkland.com:7280/
         ftp-username: mySFTPUsername
         ftp-password: ${{ secrets.SFTP_PASSWORD }}
-        git-ftp-args: --insecure # if your certificate is setup correctly this can be removed (see known-hosts argument)
+        known-hosts: [samkirkland.com]:7822 ssh-rsa AAAA...5Spw==
+        # add the following line instead  if your certificate is setup incorrectly
+        # git-ftp-args: --insecure 
 ```
 
 ### Build and Publish React/Angular/Vue Website

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'Passes through options into git-ftp'
     default: 
     required: false
+  known-hosts:
+    description: The desired content of your `.ssh/known_hosts` file
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
Hey Sam, thank you for this script. 

I had some problems setting up with the `known-hosts` argument. I found it be missing from the `action.yml`, which lead to a misleading error while running the action. I added it to `action.yml`.

Also, the example for that argument from the documentation was missing the  actual known-hosts argument, so I added that as well. I had to add the domain name in frony of "ssh-rsa" for it to work for me. My "domain" is just an IP address, I hope the syntax I added here works. It's what `ssh-keyscan` prints out when run on the domain that's used elsewhere in the examples. 

Hope this helps someone else in the future. Cheers