### PR TITLE
Add option to use ssh keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM debian:stable-slim
+FROM archlinux:20200705
 
 LABEL repository="https://github.com/SamKirkland/FTP-Deploy-Action"
 LABEL maintainer="Sam Kirkland <FTP-Deploy-Action@samkirkland.com>"
 
-RUN apt-get update
-RUN apt-get install -y git
-RUN apt-get install -y git-ftp
-RUN apt-get install -y nodejs
+RUN pacman -Sy
+RUN pacman -S --noconfirm git nodejs
+ADD https://raw.githubusercontent.com/git-ftp/git-ftp/f6dcf6218c9adae5299900f894309d1c83ebebaf/git-ftp /usr/local/bin/git-ftp
+RUN chmod +x /usr/local/bin/git-ftp
 
 COPY dist/index.js /deploy.js
 RUN chmod +x deploy.js

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,10 @@ inputs:
     required: true
   ftp-password:
     description: 'FTP account password'
-    required: true
+    required: false
+  sftp-key:
+    description: 'SFTP account key'
+    required: false
   local-dir:
     description: 'The local folder to copy, defaults to root project folder'
     default: ./

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,17 @@ import { IActionArguments } from './types';
 
 const writeFileAsync = promisify(fs.writeFile);
 const errorDeploying = "⚠️ Error deploying";
+const errorNoAuth = "⚠️ Error: No methods of authentication present! Provide action with either password (ftp_password argument) or ssh key (sftp_key argument).";
+
+const sshFolder = `${process.env['HOME']}/.ssh`;
+const sshKeyFile = `${sshFolder}/id`
+const sshKnownHostsFile = `${sshFolder}/known_hosts`
 
 async function run() {
   try {
     const userArguments = getUserArguments();
     
-    await configureHost(userArguments);
+    await configureSSH(userArguments);
     await syncFiles(userArguments);
 
     console.log("✅ Deploy Complete");
@@ -24,23 +29,24 @@ async function run() {
 
 run();
 
-async function configureHost(args: IActionArguments): Promise<void> {
-  if (args.knownHosts === "") {
+async function configureSSH(args: IActionArguments): Promise<void> {
+  if (args.knownHosts === "" && args.sftp_key === "") {
     return;
   }
 
   try {
-    const sshFolder = `${process.env['HOME']}/.ssh`;
-
     await exec.exec(`mkdir -v -p ${sshFolder}`);
     await exec.exec(`chmod 700 ${sshFolder}`);
-    writeFileAsync(`${sshFolder}/known_hosts`, args.knownHosts);
-    await exec.exec(`chmod 755 ${sshFolder}/known_hosts`);
-
-    console.log("✅ Configured known_hosts");
+    writeFileAsync(sshKnownHostsFile, args.knownHosts);
+    writeFileAsync(sshKeyFile, args.sftp_key);
+    await exec.exec(`bash -c "echo >> ${sshKeyFile}"`);
+    await exec.exec(`chmod 600 ${sshKeyFile}`);
+    await exec.exec(`chmod 755 ${sshKnownHostsFile}`);
+    
+    console.log("✅ Configured .ssh directory");
   }
   catch (error) {
-    console.error("⚠️ Error configuring known_hosts");
+    console.error("⚠️ Error configuring .ssh directory");
     core.setFailed(error.message);
   }
 }
@@ -49,7 +55,8 @@ function getUserArguments(): IActionArguments {
   return {
     ftp_server: core.getInput("ftp-server", { required: true }),
     ftp_username: core.getInput("ftp-username", { required: true }),
-    ftp_password: core.getInput("ftp-password", { required: true }),
+    ftp_password: withDefault(core.getInput("ftp-password"), ""),
+    sftp_key: withDefault(core.getInput("sftp-key"), ""),
     local_dir: withDefault(core.getInput("local-dir"), "./"),
     gitFtpArgs: withDefault(core.getInput("git-ftp-args"), ""),
     knownHosts: withDefault(core.getInput("known-hosts"), "")
@@ -57,7 +64,7 @@ function getUserArguments(): IActionArguments {
 }
 
 function withDefault(value: string, defaultValue: string) {
-  if (value === "" || value === null || value === undefined) {
+  if (value === "" || value === null || value === undefined || value === "undefined") {
     return defaultValue;
   }
 
@@ -65,20 +72,45 @@ function withDefault(value: string, defaultValue: string) {
 }
 
 /**
+ * Determine auth method from password and key strings
+ * and return string to be used by git ftp
+ * (either --paswd=<pass> or --key <path_to_keyfile>)
+ * favors key over password
+ * if none present returns empty array
+ */
+function getAuthenticationString(password: string, key: string): string[] {
+  if (key !== "") {
+    return new Array('--key', `${sshKeyFile}`);
+  } else if (password !== "") {
+    return new Array(`--passwd=${password}`);
+  } else {
+    return new Array();
+  }
+}
+
+/**
  * Sync changed files
  */
 async function syncFiles(args: IActionArguments) {
+  const authStr = getAuthenticationString(args.ftp_password!, args.sftp_key!);
+  if (authStr.length === 0) {
+    console.log(errorNoAuth);
+    core.setFailed(errorNoAuth);
+    return
+  }
+  
   try {
     await core.group("Uploading files", async () => {
       return await exec.exec(
-        "git ftp push",
+        "git-ftp",
         [
+          "push",
           "--force",
           "--auto-init",
           "--verbose",
           `--syncroot=${args.local_dir}`,
           `--user=${args.ftp_username}`,
-          `--passwd=${args.ftp_password}`,
+          ...authStr,
           args.gitFtpArgs!,
           args.ftp_server!
         ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface IActionArguments {
     ftp_server: string | undefined;
     ftp_username: string | undefined;
     ftp_password: string | undefined;
+    sftp_key: string | undefined;
 
     /** @default "." */
     local_dir: string | undefined;


### PR DESCRIPTION
Adds option to use ssh keys via sftp-key argument. I believe this would fix #63 and #79 

Couple of things that I noticed while working on this:

Passing more then one agument as one string to exec might not work. I think the reason why in #79 just adding `--key <path>` as additional arguments isn't working is the fact that it's passed as single argument. Additional arguments should probably be passed as something like:
`exec("git", <arguments>, ...args.gitFtpArgs.split(" ") )`

`core.getInput()` returns `"undefined"` for inputs that aren't set. Not undefined variable - string with value of `"undefined"`. I've added check for this in 'withDefault()'.

Finally I changed docker base to archlinux. That's the only dockerized distro I encountered that has curl working with sftp and ssh keys auth. Maybe it's me doing something wrong, I honestly have no idea. It seems to me that using sftp key with curl bellow ~7.69 throws an authentication error.