### PR TITLE
Add an output to flag a successful deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ jobs:
         port: 1234 # todo replace with your web hosts ftps port
 
     - name: ✉️ Notify
-      if: steps.deployment.deployed == 'true'
+      if: steps.deployment.outputs.deployed == 'true'
       run: notify-people-of-my-deployment
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,34 @@ jobs:
           - node_modules/**/*
 ```
 
+#### Only run an action if a deployment happened
+
+```yml
+on: push
+name: 🚀 Deploy website on push
+jobs:
+  web-deploy:
+    name: 🎉 Deploy
+    runs-on: ubuntu-latest
+    steps:
+    - name: 🚚 Get latest code
+      uses: actions/checkout@v2.3.2
+
+    - name: 📂 Sync files
+      id: deployment
+      uses: SamKirkland/FTP-Deploy-Action@4.0.0
+      with:
+        server: ftp.samkirkland.com
+        username: myFtpUserName
+        password: ${{ secrets.password }}
+        protocol: ftps
+        port: 1234 # todo replace with your web hosts ftps port
+
+    - name: ✉️ Notify
+      if: steps.deployment.deployed == 'true'
+      run: notify-people-of-my-deployment
+```
+
 _Want another example? Let me know by creating a [github issue](https://github.com/SamKirkland/FTP-Deploy-Action/issues/new)_
 
 ---

--- a/dist/index.js
+++ b/dist/index.js
@@ -6570,9 +6570,11 @@ async function runDeployment() {
             "security": parse_1.optionalSecurity("security", core.getInput("security"))
         };
         await ftp_deploy_1.deploy(args);
+        core.setOutput('deployed', 'true');
     }
     catch (error) {
         core.setFailed(error);
+        core.setOutput('deployed', 'false');
     }
 }
 runDeployment();

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,9 +22,11 @@ async function runDeployment() {
     };
 
     await deploy(args);
+    core.setOutput('deployed', 'true');
   }
   catch (error) {
     core.setFailed(error);
+    core.setOutput('deployed', 'false');
   }
 }
 


### PR DESCRIPTION
Adding an output variable to flag if a deployment was successful. 

This can be helpful in situation when one wants to run jobs only if a deployment was successful. 