### PR TITLE
Fixed security options to be reflected

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2069,7 +2069,7 @@ function connect(client, args, logger) {
             secure = "implicit";
         }
         client.ftp.verbose = args["log-level"] === "verbose";
-        const rejectUnauthorized = args.security === "loose";
+        const rejectUnauthorized = args.security === "strict";
         yield client.access({
             host: args.server,
             user: args.username,


### PR DESCRIPTION
Hello. Thanks for the very useful software. I am using it to deploy my site.

I found that the certificate is still being checked even with the `security` option set to `loose`.
To avoid certificate checking, we have to set rejectUnauthorized to false, but I think the current implementation sets rejectUnauthorized to true if the `security` option is `loose`.
I have changed the implementation of the relevant part.

I think https://github.com/SamKirkland/FTP-Deploy-Action/issues/149 is relevant.

Please let me know if there are any mistakes or if there is anything additional I should do.

Thanks.