### PR TITLE
Fixed bug of move current directory after deleting directory

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2354,7 +2354,7 @@ class FTPSyncProvider {
                 }
             }
             // navigate back to the root folder
-            yield this.upDir((_a = path.folders) === null || _a === void 0 ? void 0 : _a.length - 1);
+            // yield this.upDir((_a = path.folders) === null || _a === void 0 ? void 0 : _a.length);
             this.logger.verbose(`  completed`);
         });
     }


### PR DESCRIPTION
after removing directory, current directory is restored.
https://github.com/SamKirkland/FTP-Deploy-Action/blob/59992de6c6cbed8ff0e5d7d3a664541d253a57b3/dist/index.js#L2353
https://github.com/SamKirkland/FTP-Deploy-Action/blob/59992de6c6cbed8ff0e5d7d3a664541d253a57b3/dist/index.js#L3321

so, no need to go back current directory.
https://github.com/SamKirkland/FTP-Deploy-Action/blob/59992de6c6cbed8ff0e5d7d3a664541d253a57b3/dist/index.js#L2357