### PR TITLE
v4.3.6 🚀

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3626,7 +3626,7 @@ class FTPSyncProvider {
                 }
                 catch (e) {
                     // this error is common when a file was deleted on the server directly
-                    if (e.code === types_1.ErrorCode.FileNotFoundOrNoAccess) {
+                    if ((e === null || e === void 0 ? void 0 : e.code) === types_1.ErrorCode.FileNotFoundOrNoAccess) {
                         this.logger.standard("File not found or you don't have access to the file - skipping...");
                     }
                     else {
@@ -3643,7 +3643,17 @@ class FTPSyncProvider {
             const absoluteFolderPath = "/" + (this.serverPath.startsWith("./") ? this.serverPath.replace("./", "") : this.serverPath) + folderPath;
             this.logger.all(`removing folder "${absoluteFolderPath}"`);
             if (this.dryRun === false) {
-                yield (0, utilities_1.retryRequest)(this.logger, () => __awaiter(this, void 0, void 0, function* () { return yield this.client.removeDir(absoluteFolderPath); }));
+                try {
+                    yield (0, utilities_1.retryRequest)(this.logger, () => __awaiter(this, void 0, void 0, function* () { return yield this.client.removeDir(absoluteFolderPath); }));
+                }
+                catch (e) {
+                    if ((e === null || e === void 0 ? void 0 : e.code) === types_1.ErrorCode.FileNotFoundOrNoAccess) {
+                        this.logger.standard("Directory not found or you don't have access to the file - skipping...");
+                    }
+                    else {
+                        throw e;
+                    }
+                }
             }
             this.logger.verbose(`  completed`);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",
-        "@samkirkland/ftp-deploy": "^1.2.4",
+        "@samkirkland/ftp-deploy": "^1.2.5",
         "@types/jest": "^29.4.1",
         "jest": "^29.5.0",
         "ts-jest": "^29.0.5",
@@ -1097,9 +1097,10 @@
       }
     },
     "node_modules/@samkirkland/ftp-deploy": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@samkirkland/ftp-deploy/-/ftp-deploy-1.2.4.tgz",
-      "integrity": "sha512-MF5BoP1mQS3HBdx2pTMX/sIxSt9S4IgdL6ttrcGpUWC9U/IIPcUnyVEQiiBQJePLXpHI93dT9b8VDoS+cUknNg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@samkirkland/ftp-deploy/-/ftp-deploy-1.2.5.tgz",
+      "integrity": "sha512-UZJKpb46FOGLmjgLiQDmzU/3zZUP1ckCaJG6xaHQ1igAGydLm6ctYmQO9gupJYs3HzEYkLXzU5AZGOb4RuHTjw==",
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.5",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.9.1",
-    "@samkirkland/ftp-deploy": "^1.2.4",
+    "@samkirkland/ftp-deploy": "^1.2.5",
     "@types/jest": "^29.4.1",
     "jest": "^29.5.0",
     "ts-jest": "^29.0.5",


### PR DESCRIPTION
Improved error handling when removing directories during FTP operations. In certain cases, the target directory may already be unavailable (e.g., deleted, renamed, or removed by a build process). Instead of throwing an exception, the process now logs a warning informing the user that the directory could not be removed or accessed.
What's Changed

Fixing folder 550 delete action by @konnng-dev in https://github.com/SamKirkland/ftp-deploy/pull/47